### PR TITLE
feat: Agregar historial de compras con CRUD completo y modo oscuro

### DIFF
--- a/lib/database/db_helper.dart
+++ b/lib/database/db_helper.dart
@@ -1,57 +1,75 @@
 import 'package:sqflite/sqflite.dart';
 import 'package:path/path.dart';
-import '../models/product.dart';
+import '../models/compra.dart';
 
-class DBHelper {
-  static Database? _db;
-  static const String DB_NAME = 'supermercado.db';
-  static const String TABLE = 'products';
+class DatabaseHelper {
+  static final DatabaseHelper instance = DatabaseHelper._internal();
+  static Database? _database;
 
-  static Future<Database> get database async {
-    if (_db != null) return _db!;
-    _db = await initDB();
-    return _db!;
+  DatabaseHelper._internal();
+
+  Future<Database> get database async {
+    if (_database != null) return _database!;
+    _database = await _initDatabase();
+    return _database!;
   }
 
-  static initDB() async {
-    var dbPath = await getDatabasesPath();
-    String path = join(dbPath, DB_NAME);
+  Future<Database> _initDatabase() async {
+    final path = join(await getDatabasesPath(), 'app2market.db');
 
-    return await openDatabase(path, version: 1, onCreate: (db, version) async {
-      await db.execute('''
-        CREATE TABLE $TABLE (
-          id INTEGER PRIMARY KEY AUTOINCREMENT,
-          name TEXT NOT NULL,
-          price REAL NOT NULL
-        )
-      ''');
-    });
+    return await openDatabase(
+      path,
+      version: 1,
+      onCreate: _onCreate,
+    );
   }
 
-  static Future<int> insertProduct(Product product) async {
+  Future<void> _onCreate(Database db, int version) async {
+    await db.execute('''
+      CREATE TABLE compras (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        fecha TEXT,
+        total REAL,
+        productos TEXT
+      )
+    ''');
+  }
+
+  Future<void> insertarCompra(Compra compra) async {
     final db = await database;
-    return await db.insert(TABLE, product.toMap());
+    await db.insert(
+      'compras',
+      compra.toMap(),
+      conflictAlgorithm: ConflictAlgorithm.replace,
+    );
   }
 
-  static Future<List<Product>> getProducts() async {
+  Future<List<Compra>> obtenerHistorial() async {
     final db = await database;
-    final List<Map<String, dynamic>> maps = await db.query(TABLE);
-    return List.generate(maps.length, (i) => Product.fromMap(maps[i]));
+    final List<Map<String, dynamic>> maps = await db.query(
+      'compras',
+      orderBy: 'fecha DESC',
+    );
+    return List.generate(maps.length, (i) => Compra.fromMap(maps[i]));
   }
 
-  static Future<int> updateProduct(Product product) async {
+  Future<void> actualizarCompra(Compra compra) async {
     final db = await database;
-    return await db.update(TABLE, product.toMap(),
-        where: 'id = ?', whereArgs: [product.id]);
+    await db.update(
+      'compras',
+      compra.toMap(),
+      where: 'id = ?',
+      whereArgs: [compra.id],
+    );
   }
 
-  static Future<int> deleteProduct(int id) async {
+  Future<void> eliminarCompra(int id) async {
     final db = await database;
-    return await db.delete(TABLE, where: 'id = ?', whereArgs: [id]);
-  }
-
-  static Future<int> deleteAll() async {
-    final db = await database;
-    return await db.delete(TABLE);
+    await db.delete(
+      'compras',
+      where: 'id = ?',
+      whereArgs: [id],
+    );
   }
 }
+

--- a/lib/models/compra.dart
+++ b/lib/models/compra.dart
@@ -1,0 +1,33 @@
+class Compra {
+  final int? id;
+  final DateTime fecha;
+  final double total;
+  final List<String> productos;
+
+  Compra({
+    this.id,
+    required this.fecha,
+    required this.total,
+    required this.productos,
+  });
+
+  // Para guardar en SQLite
+  Map<String, dynamic> toMap() {
+    return {
+      'id': id,
+      'fecha': fecha.toIso8601String(),
+      'total': total,
+      'productos': productos.join(','),
+    };
+  }
+
+  // Para leer desde SQLite
+  factory Compra.fromMap(Map<String, dynamic> map) {
+    return Compra(
+      id: map['id'],
+      fecha: DateTime.parse(map['fecha']),
+      total: map['total'],
+      productos: map['productos'].split(','),
+    );
+  }
+}

--- a/lib/screens/pantalla_historial.dart
+++ b/lib/screens/pantalla_historial.dart
@@ -1,6 +1,6 @@
 import 'package:flutter/material.dart';
 import '../models/compra.dart';
-import '../database/db_helper.dart';
+import '/database/db_helper.dart';
 
 class PantallaHistorial extends StatefulWidget {
   const PantallaHistorial({Key? key}) : super(key: key);
@@ -32,7 +32,7 @@ class _PantallaHistorialState extends State<PantallaHistorial> {
 
   void editar(Compra compra) {
     final controladorTotal = TextEditingController(text: compra.total.toString());
-    final controladorProductos = TextEditingController(text: compra.productos.join(','));
+    final controladorProductos = TextEditingController(text: compra.productos.join(', '));
 
     showDialog(
       context: context,


### PR DESCRIPTION
Este PR agrega la funcionalidad completa de historial de compras en la app, incluyendo:

Guardar nuevas compras con productos y total.

Visualizar el historial con fecha, total y lista de productos.

Editar y eliminar compras desde el historial.

Gestión de productos en la pantalla principal: agregar, modificar y borrar.

Implementación de modo oscuro y navegación entre pantallas.